### PR TITLE
Add missing ScalaDocs to Scala CRUD example

### DIFF
--- a/scala/faunadb-crud-example-app/README.md
+++ b/scala/faunadb-crud-example-app/README.md
@@ -416,11 +416,11 @@ Select(
 ```
 
 #### References:
-* [Create](https://app.fauna.com/documentation/reference/queryapi#create)
-* [Replace](https://app.fauna.com/documentation/reference/queryapi#replace)
-* [Select](https://app.fauna.com/documentation/reference/queryapi#select)
-* [If](https://app.fauna.com/documentation/reference/queryapi#if)
-* [Exists](https://app.fauna.com/documentation/reference/queryapi#exists)
+* [Create](https://docs.fauna.com/fauna/current/reference/queryapi/write/create)
+* [Replace](https://docs.fauna.com/fauna/current/reference/queryapi/write/replace)
+* [Select](https://docs.fauna.com/fauna/current/reference/queryapi/read/select)
+* [If](https://docs.fauna.com/fauna/current/reference/queryapi/basic/if)
+* [Exists](https://docs.fauna.com/fauna/current/reference/queryapi/logical/exists)
 
 ### Save several Posts
 It saves several Posts within a single transaction. It uses the `Map` function to iterate over a collection of entities and apply the above save query to them.
@@ -434,8 +434,8 @@ Map(
 ```
 
 #### References:
-* [Map](https://app.fauna.com/documentation/reference/queryapi#map)
-* [Lambda](https://app.fauna.com/documentation/reference/queryapi#lambda)
+* [Map](https://docs.fauna.com/fauna/current/reference/queryapi/collection/map)
+* [Lambda](https://docs.fauna.com/fauna/current/reference/queryapi/basic/lambda)
 
 ### Find a Post
 It looks up a Post by its Id and returns its data back. 
@@ -447,8 +447,8 @@ Select(
 )
 ```
 #### References:
-* [Select](https://app.fauna.com/documentation/reference/queryapi#select)
-* [Get](https://app.fauna.com/documentation/reference/queryapi#get)
+* [Select](https://docs.fauna.com/fauna/current/reference/queryapi/read/select)
+* [Get](https://docs.fauna.com/fauna/current/reference/queryapi/read/get)
 
 
 ### Find all Posts
@@ -464,12 +464,12 @@ Map(
 ```
 
 #### References:
-* [Paginate](https://app.fauna.com/documentation/reference/queryapi#paginate)
-* [Match](https://app.fauna.com/documentation/reference/queryapi#matchindexref-terms)
-* [SelectAll](https://app.fauna.com/documentation/reference/queryapi#selectall)
-* [Map](https://app.fauna.com/documentation/reference/queryapi#map)
-* [Lambda](https://app.fauna.com/documentation/reference/queryapi#lambda)
-* [Get](https://app.fauna.com/documentation/reference/queryapi#get)
+* [Paginate](https://docs.fauna.com/fauna/current/reference/queryapi/read/paginate)
+* [Match](https://docs.fauna.com/fauna/current/reference/queryapi/set/match)
+* [SelectAll](https://docs.fauna.com/fauna/current/reference/queryapi/read/selectall)
+* [Map](https://docs.fauna.com/fauna/current/reference/queryapi/collection/map)
+* [Lambda](https://docs.fauna.com/fauna/current/reference/queryapi/basic/lambda)
+* [Get](https://docs.fauna.com/fauna/current/reference/queryapi/read/get)
 
 ### Find Posts by Title
 It looks up all Posts matching the given Title and returns its data. The search is done using a previsouly created `Index`.  First, all Posts Ids are found using the `Index` together with the `Paginate` function and then its data is looked up through the `Get` function.
@@ -484,12 +484,12 @@ Map(
 ```
 
 #### References:
-* [Paginate](https://app.fauna.com/documentation/reference/queryapi#paginate)
-* [Match](https://app.fauna.com/documentation/reference/queryapi#matchindexref-terms)
-* [SelectAll](https://app.fauna.com/documentation/reference/queryapi#selectall)
-* [Map](https://app.fauna.com/documentation/reference/queryapi#map)
-* [Lambda](https://app.fauna.com/documentation/reference/queryapi#lambda)
-* [Get](https://app.fauna.com/documentation/reference/queryapi#get)
+* [Paginate](https://docs.fauna.com/fauna/current/reference/queryapi/read/paginate)
+* [Match](https://docs.fauna.com/fauna/current/reference/queryapi/set/match)
+* [SelectAll](https://docs.fauna.com/fauna/current/reference/queryapi/read/selectall)
+* [Map](https://docs.fauna.com/fauna/current/reference/queryapi/collection/map)
+* [Lambda](https://docs.fauna.com/fauna/current/reference/queryapi/basic/lambda)
+* [Get](https://docs.fauna.com/fauna/current/reference/queryapi/read/get)
 
 
 ### Remove a Post
@@ -503,5 +503,5 @@ Select(
 ```
 
 #### References:
-* [Delete](https://app.fauna.com/documentation/reference/queryapi#delete)
-* [Select](https://app.fauna.com/documentation/reference/queryapi#select)
+* [Delete](https://docs.fauna.com/fauna/current/reference/queryapi/write/delete)
+* [Select](https://docs.fauna.com/fauna/current/reference/queryapi/read/select)

--- a/scala/faunadb-crud-example-app/src/main/scala/model/Post.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/model/Post.scala
@@ -1,5 +1,22 @@
 package model
 
+/**
+  * A Post entity.
+  *
+  * It represents a simple Post, like the one in a Blog,
+  * along with some basic attributes.
+  *
+  * @param id the Post Id
+  * @param title the Post title
+  * @param tags the Post tags
+  */
 case class Post(id: String, title: String, tags: Seq[String]) extends Entity
 
+/**
+  * It contains all the necessary data, with the exception of
+  * the Id, for creating or replacing a [[model.Post Post]] entity.
+  *
+  * @param title the Post title
+  * @param tags the Post tags
+  */
 case class CreateReplacePostData(title: String, tags: Seq[String])

--- a/scala/faunadb-crud-example-app/src/main/scala/model/common.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/model/common.scala
@@ -13,19 +13,33 @@ trait Entity {
   * It represents a sequence of elements along with
   * cursors indicators to move backwards and forwards.
   *
+  * Note that this class does not mean to model Fauna's Page
+  * object, but to be a database agnostic page abstraction.
+  *
+  * One of the main differences with Fauna's Page is that the
+  * latter offers a broader flexibility when it comes to the definition
+  * of which elements can be contained within the data and cursors fields.
+  * Those elements, which are defined during the creation of the Index
+  * from which the Page is being derived, has been constrained in this
+  * example in order to keep a simple design. Nonetheless, be aware that
+  * Fauna's Indexes and Pages can be used to build more complex results.
+  *
   * @param data the data within the current sequence
-  * @param before the before cursor – if any, it contains the Id of the previous record before the current sequence
-  * @param after the after cursor – if any, it contains the Id of the next record after the current sequence
+  * @param before the before cursor – if any, it contains the Id of the previous record before the current sequence of data
+  * @param after the after cursor – if any, it contains the Id of the next record after the current sequence of data
   * @tparam A the type of data within the sequence
+  *
+  * @see [[https://app.fauna.com/documentation/reference/queryapi#page Index]]
+  * @see [[https://app.fauna.com/documentation/reference/queryapi#page Page]]
+  * @see [[https://app.fauna.com/documentation/reference/queryapi#cursor Cursor]]
   */
 case class Page[A](data: Seq[A], before: Option[String], after: Option[String])
 
 /**
   * It defines parameters for looking up a result using pagination.
   *
-  *
-  * @param size the size of the requested results
-  * @param before the before cursor – if any, it indicates the requested result should
-  * @param after the after cursor – if any, it contains the Id of the next record after the current sequence
+  * @param size the max number of elements to return in the requested Page
+  * @param before the before cursor – if any, it indicates to return the previous Page of results before this Id (exclusive)
+  * @param after the after cursor –  if any, it indicates to return the next Page of results after this Id (inclusive)
   */
 case class PaginationOptions(size: Option[Int], before: Option[String], after: Option[String])

--- a/scala/faunadb-crud-example-app/src/main/scala/model/common.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/model/common.scala
@@ -29,9 +29,8 @@ trait Entity {
   * @param after the after cursor – if any, it contains the Id of the next record after the current sequence of data
   * @tparam A the type of data within the sequence
   *
-  * @see [[https://app.fauna.com/documentation/reference/queryapi#page Index]]
-  * @see [[https://app.fauna.com/documentation/reference/queryapi#page Page]]
-  * @see [[https://app.fauna.com/documentation/reference/queryapi#cursor Cursor]]
+  * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/types.html#page Page]]
+  * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/write/createindex Index]]
   */
 case class Page[A](data: Seq[A], before: Option[String], after: Option[String])
 
@@ -40,6 +39,6 @@ case class Page[A](data: Seq[A], before: Option[String], after: Option[String])
   *
   * @param size the max number of elements to return in the requested Page
   * @param before the before cursor – if any, it indicates to return the previous Page of results before this Id (exclusive)
-  * @param after the after cursor –  if any, it indicates to return the next Page of results after this Id (inclusive)
+  * @param after the after cursor – if any, it indicates to return the next Page of results after this Id (inclusive)
   */
 case class PaginationOptions(size: Option[Int], before: Option[String], after: Option[String])

--- a/scala/faunadb-crud-example-app/src/main/scala/persistence/FaunaRepository.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/persistence/FaunaRepository.scala
@@ -9,11 +9,19 @@ import model.{Entity, Page, PaginationOptions}
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/**
+  * Base Repository implementation backed by FaunaDB.
+  *
+  * @tparam A [[model.Entity Entity]] type the Repository will be modelled after
+  * @see [[https://fauna.com/ FaunaDB]]
+  */
 trait FaunaRepository[A <: Entity] extends Repository[A] with FaunaRepository.Implicits {
-
-  // Note: using Scala's global ExecutionContext for now.
-  // Evaluate the use of a a dedicated ExecutionContext for
-  // the persistence layer (bulkheading) in a prod environment.
+  /*
+   * Note: using Scala's global ExecutionContext for keeping
+   * the example with a simple design. Evaluate the use of a
+   * dedicated ExecutionContext for the persistence layer
+   * (bulkheading) in a prod environment.
+   */
   implicit protected val ec: ExecutionContext = ExecutionContext.global
 
   protected val client: FaunaClient
@@ -23,18 +31,38 @@ trait FaunaRepository[A <: Entity] extends Repository[A] with FaunaRepository.Im
 
   implicit protected val codec: Codec[A]
 
+  /**
+    * It returns a unique valid Id leveraging Fauna's NewId function.
+    *
+    * The produced Id is guaranteed to be unique across the entire
+    * cluster and once generated will never be generated a second time.
+    *
+    * @return a unique valid Id
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/misc/newid NewId]]
+    */
   def nextId(): Future[String] = {
-    val result: Future[Value] = client.query(
+    val result = client.query(
       NewId()
     )
 
     result.decode[String]
   }
 
+  /**
+    * It returns a sequence of unique valid Ids leveraging Fauna's NewId function.
+    *
+    * The produced Ids are guaranteed to be unique across the entire
+    * cluster and once generated will never be generated a second time.
+    *
+    * @param size the number of unique Ids to return
+    * @return a sequence of unique valid Ids
+    *
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/misc/newid NewId]]
+    */
   def nextIds(size: Int): Future[Seq[String]] = {
     val indexes = (1 to size).toList
 
-    val result: Future[Value] = client.query(
+    val result = client.query(
       Map(
         indexes,
         Lambda(_ => NewId())
@@ -44,15 +72,32 @@ trait FaunaRepository[A <: Entity] extends Repository[A] with FaunaRepository.Im
     result.decode[Seq[String]]
   }
 
+  /**
+    * @inheritdoc
+    *
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/write/create Create]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/write/replace Replace]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/basic/if If]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/logical/exists Exists]]
+    */
   override def save(entity: A): Future[A] = {
-    val result: Future[Value] = client.query(
+    val result = client.query(
       saveQuery(entity.id, entity)
     )
     result.decode[A]
   }
 
+  /**
+    * @inheritdoc
+    *
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/write/create Create]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/write/replace Replace]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/basic/if If]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/logical/exists Exists]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/collection/map Map]]
+    */
   override def saveAll(entities: A*): Future[Seq[A]] = {
-    val result: Future[Value] = client.query(
+    val result = client.query(
       Map(
         entities,
         Lambda { nextEntity =>
@@ -65,8 +110,13 @@ trait FaunaRepository[A <: Entity] extends Repository[A] with FaunaRepository.Im
     result.decode[Seq[A]]
   }
 
+  /**
+    * @inheritdoc
+    *
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/write/delete Delete]]
+    */
   override def remove(id: String): Future[Option[A]] = {
-    val result: Future[Value] = client.query(
+    val result = client.query(
       Select(
         "data",
         Delete(Ref(Class(className), id))
@@ -76,31 +126,53 @@ trait FaunaRepository[A <: Entity] extends Repository[A] with FaunaRepository.Im
     result.optDecode[A]
   }
 
+  /**
+    * @inheritdoc
+    *
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/read/get Get]]
+    */
   override def find(id: String): Future[Option[A]] = {
-    val result: Future[Value] = client.query(
+    val result = client.query(
       Select("data", Get(Ref(Class(className), id)))
     )
 
     result.optDecode[A]
   }
 
+  /**
+    * @inheritdoc
+    *
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/read/paginate Paginate]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/collection/map Map]]
+    */
   def findAll()(implicit po: PaginationOptions): Future[Page[A]] = {
     val beforeCursor = po.before.map(id => Before(Ref(Class(className), id)))
     val afterCursor = po.after.map(id => After(Ref(Class(className), id)))
     val cursor = beforeCursor.orElse(afterCursor).getOrElse(NoCursor)
 
-    val result: Future[Value] = {
-      client.query(
-        Map(
-          Paginate(Match(Index(classIndexName)), size = po.size, cursor = cursor),
-          Lambda(nextRef => Select("data", Get(nextRef)))
-        )
+    val result = client.query(
+      Map(
+        Paginate(Match(Index(classIndexName)), size = po.size, cursor = cursor),
+        Lambda(nextRef => Select("data", Get(nextRef)))
       )
-    }
+    )
 
     result.decode[Page[A]]
   }
 
+  /**
+    * It leverages Fauna Query Language enriched features to build
+    * a transactional query for performing a valid [[persistence.Repository#save Repository#save]] operation.
+    *
+    * @param id the Id of the Entity to be saved
+    * @param data the data of the Entity to be saved
+    * @return a query for performing a valid [[persistence.Repository#save Repository#save]] operation
+    *
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/write/create Create]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/write/replace Replace]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/basic/if If]]
+    * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/logical/exists Exists]]
+    */
   protected def saveQuery(id: Expr, data: Expr): Expr =
     Select(
       "data",
@@ -117,8 +189,31 @@ object FaunaRepository {
 
   trait Implicits {
 
+    /**
+      * It returns an implicit [[faunadb.values.Decoder Decoder]] for converting
+      * from a [[faunadb.values.Value Value]] into a [[model.Page Page]].
+      *
+      * In order this to work, there must be an implicit [[faunadb.values.Decoder Decoder]] for the
+      * concrete [[model.Page Page]]'s [[model.Entity Entity]] type in scope. At the same time, the [[faunadb.values.Value Value]] to
+      * convert from must be of a Fauna Page type.
+      *
+      * @param decoder [[faunadb.values.Decoder Decoder]] for [[model.Page Page]]'s type parameter
+      * @tparam A [[model.Page Page]]'s type parameter
+      * @return an implicit [[faunadb.values.Decoder Decoder]] for [[model.Page Page]]
+      *
+      * @see [[https://github.com/fauna/faunadb-jvm/blob/master/docs/scala.md#how-to-work-with-user-defined-classes Encoding and decoding user defined classes]]
+      * @see [[https://docs.fauna.com/fauna/current/reference/queryapi/types.html#page Page]]
+      */
     implicit def pageDecoder[A](implicit decoder: Decoder[A]): Decoder[Page[A]] = new Decoder[Page[A]] {
       def decode(v: Value, path: FieldPath): Result[Page[A]] = {
+        /*
+         * Note that below code for extracting the data within the "after"
+         * and the "before" cursors directly depends on the definition of
+         * the Index from which the Page is being derived. For this particular
+         * case, the Index return values should only contain the Ref field
+         * from the Instances being covered by the Index. If the Index return
+         * values should contain more fields, update below code accordingly.
+         */
         val before = v("before").to[Seq[RefV]].map(_.head.id).toOpt
         val after = v("after").to[Seq[RefV]].map(_.head.id).toOpt
 
@@ -132,8 +227,28 @@ object FaunaRepository {
     }
 
     implicit class ExtendedFutureValue(value: Future[Value]) {
+
+      /**
+        * It converts a [[faunadb.values.Value Value]] into an `Object` of
+        * the given [[faunadb.values.Decoder Decoder]]'s type.
+        *
+        * @tparam A the type to convert to
+        * @return the converted `Object` from the given [[faunadb.values.Value]]
+        */
       def decode[A: Decoder](implicit ec: ExecutionContext): Future[A] = value.map(_.to[A].get)
 
+      /**
+        * It recovers from a [[faunadb.errors.NotFoundException NotFoundException]]
+        * with an [[scala.Option Option]] result.
+        *
+        * If it's a [[scala.util.Success Success]] value, it wraps the value within a [[scala.Some Some]] result.
+        *
+        * If it's a [[scala.util.Failure Failure]] value caused by a [[faunadb.errors.NotFoundException NotFoundException]],
+        * it returns [[scala.None None]] result.
+        *
+        * @tparam A the type to convert to
+        * @return
+        */
       def optDecode[A: Decoder](implicit ec: ExecutionContext): Future[Option[A]] =
         value
           .decode[A]
@@ -147,7 +262,11 @@ object FaunaRepository {
   object Implicits extends Implicits
 }
 
-// Settings
+/**
+  * Settings class for setting up a [[faunadb.FaunaClient FaunaClient]].
+  *
+  * @param config base [[com.typesafe.config.Config Config]] for reading the settings from
+  */
 class FaunaSettings(config: Config) {
   private val faunaConfig = config.getConfig("fauna-db")
   val endpoint = faunaConfig.getString("endpoint")

--- a/scala/faunadb-crud-example-app/src/main/scala/persistence/PostRepository.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/persistence/PostRepository.scala
@@ -2,25 +2,35 @@ package persistence
 
 import faunadb.FaunaClient
 import faunadb.query.{Map, _}
-import faunadb.values.{Codec, Value}
+import faunadb.values.Codec
 import model.{Page, PaginationOptions, Post}
 
 import scala.concurrent.Future
 
+/**
+  * [[persistence.FaunaRepository FaunaRepository]] implementation for the [[model.Post Post]] entity.
+  */
 class PostRepository(faunaClient: FaunaClient) extends FaunaRepository[Post] {
   override protected val client: FaunaClient = faunaClient
-  override protected val className: String = "posts"
-  override protected val classIndexName: String = "all_posts"
+  override protected val className = "posts"
+  override protected val classIndexName = "all_posts"
   implicit override protected val codec: Codec[Post] = Codec.Record[Post]
 
   //-- Custom repository operations specific to the current entity go below --//
 
+  /**
+    * It finds all Posts matching the given title.
+    *
+    * @param title title to find Posts by
+    * @param po the [[model.PaginationOptions PaginationOptions]] to determine which [[model.Page Page]] of results to return
+    * @return a [[model.Page Page]] of [[model.Post Post]] entities
+    */
   def findByTitle(title: String)(implicit po: PaginationOptions): Future[Page[Post]] = {
     val beforeCursor = po.before.map(id => Before(Ref(Class(className), id)))
     val afterCursor = po.after.map(id => After(Ref(Class(className), id)))
     val cursor = beforeCursor.orElse(afterCursor).getOrElse(NoCursor)
 
-    val result: Future[Value] =
+    val result =
       client.query(
         Map(
           Paginate(Match(Index("posts_by_title"), title), size = po.size, cursor = cursor),

--- a/scala/faunadb-crud-example-app/src/main/scala/persistence/common.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/persistence/common.scala
@@ -9,27 +9,91 @@ import scala.concurrent.Future
   *
   * It defines a set of base methods mimicking a collection API.
   *
-  * Note: unlike DAOs, which are designed following a data access
+  * Note that unlike DAOs, which are designed following a data access
   * orientation, Repositories are implemented following a collection
-  * orientation. The focus should be put on the domain as a model
-  * rather than on data and any CRUD operations that may be used behind
-  * the scenes to manage its persistence.
+  * orientation. This means that instead of exposing a set of CRUD
+  * operations for a data model, a Repository interface will resemble
+  * the one of a Collection for a domain model.
   *
+  * @tparam A [[model.Entity Entity]] type the Repository will be modelled after
   */
 trait Repository[A <: Entity] extends IdentityFactory {
+
+  /**
+    * It saves the given Entity into the Repository.
+    *
+    * If an Entity with the same Id already exists in
+    * the Repository, it will be replaced with the one
+    * supplied.
+    *
+    * @param entity  the Entity to be saved
+    * @return the saved Entity
+    */
   def save(entity: A): Future[A]
+
+  /**
+    * It saves all the given Entities into the Repository.
+    *
+    * If an Entity with the same Id already exists in
+    * the Repository for any of the given Entities, it
+    * will be replaced with the one supplied.
+    *
+    * @param entities the Entities to be saved
+    * @return the saved Entities
+    */
   def saveAll(entities: A*): Future[Seq[A]]
+
+  /**
+    * It finds the Entity for the given Id and
+    * removes it. If no Entity can be found for
+    * the given Id an empty result is returned.
+    *
+    * @param id the Id of the Entity to be removed
+    * @return the removed Entity if found or an empty result if not
+    */
   def remove(id: String): Future[Option[A]]
+
+  /**
+    * It finds an Entity for the given Id.
+    *
+    * @param id the Id of the Entity to be found
+    * @return the Entity if found or an empty result if not
+    */
   def find(id: String): Future[Option[A]]
+
+  /**
+    * It retrieves a [[model.Page Page]] of entities
+    * for the given [[model.PaginationOptions PaginationOptions]].
+    *
+    * @param po the [[model.PaginationOptions PaginationOptions]] to determine which [[model.Page Page]] of results to return
+    * @return a [[model.Page Page]] of entities
+    */
   def findAll()(implicit po: PaginationOptions): Future[Page[A]]
 }
 
 /**
-  * Base trait for implementing an Identity factory. It enables
-  * support for early Identity generation and assignment
-  * (i.e. before the Entity is saved into the Repository).
+  * It defines the base operations for implementing an Identity factory.
+  *
+  * It enables support for early Identity generation and assignment, that is
+  * before the Entity is saved into the Repository. This allows to decouple the
+  * operations of generating the Id and saving the Entity from each other. This
+  * pattern lets among other things to create an Entity with all of its mandatory
+  * fields and get rid of inconsistent states, i.e having an Entity with a null Id.
   */
 trait IdentityFactory {
+
+  /**
+    * It returns a unique valid Id.
+    *
+    * @return a unique valid Id
+    */
   def nextId(): Future[String]
+
+  /**
+    * It returns a sequence of unique valid Ids with the given size.
+    *
+    * @param size the number of unique Ids to return
+    * @return a sequence of unique valid Ids
+    */
   def nextIds(size: Int): Future[Seq[String]]
 }

--- a/scala/faunadb-crud-example-app/src/main/scala/rest/PostEndpoint.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/rest/PostEndpoint.scala
@@ -5,6 +5,9 @@ import akka.http.scaladsl.server.Route
 import model.{CreateReplacePostData, PaginationOptions}
 import services.PostService
 
+/**
+  * REST endpoint for the [[model.Post Post]] entity.
+  */
 class PostEndpoint(postService: PostService) extends RestEndpoint {
 
   def createPost: Route =

--- a/scala/faunadb-crud-example-app/src/main/scala/rest/RestServer.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/rest/RestServer.scala
@@ -12,7 +12,9 @@ import faunadb.FaunaClient
 import scala.util.{Failure, Success, Try}
 
 /**
-  * RestServer backed by Akka HTTP. Alla Akka references are encapsulated here.
+  * RestServer backed by Akka HTTP.
+  *
+  * @see [[https://doc.akka.io/docs/akka-http/current/ Akka HTTP]]
   */
 object RestServer {
 

--- a/scala/faunadb-crud-example-app/src/main/scala/rest/common.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/rest/common.scala
@@ -14,10 +14,10 @@ trait RestEndpoint extends Directives with Json4sJacksonSupport {
 /**
   * Json4sSupport backed by Jackson serialization.
   *
-  * Json4sSupport allows automatic (un)marshalling from/into Json
+  * Json4sSupport allows automatic de/serialization from/into JSON
   * without providing any custom type class in scope.
   *
-  * More info at: https://github.com/hseeberger/akka-http-json
+  * @see [[https://github.com/hseeberger/akka-http-json akka-http-json]]
   */
 trait Json4sJacksonSupport extends Json4sSupport {
   implicit val serialization = native.Serialization

--- a/scala/faunadb-crud-example-app/src/main/scala/services/PostService.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/services/PostService.scala
@@ -5,11 +5,23 @@ import persistence.PostRepository
 
 import scala.concurrent.Future
 
+/**
+  * Domain Service for the [[model.Post Post]] entity.
+  */
 class PostService(repository: PostRepository) extends Service {
 
+  /**
+    * It builds up a new [[model.Post Post]] entity with the
+    * given [[model.CreateReplacePostData CreateReplacePostData]]
+    * and a generated valid Id. Then, it saves the new entity into
+    * the repository.
+    *
+    * @param data the data to create the new Post entity
+    * @return the new created Post entity
+    */
   def createPost(data: CreateReplacePostData): Future[Post] = {
     // Save
-    val result: Future[Post] =
+    val result =
       for {
         id <- repository.nextId()
         post <- repository.save(Post(id, data.title, data.tags))
@@ -18,6 +30,15 @@ class PostService(repository: PostRepository) extends Service {
     result
   }
 
+  /**
+    * It builds up a several [[model.Post Post]] entities with the
+    * given [[model.CreateReplacePostData CreateReplacePostData]] objects
+    * and generated valid Ids. Then, it saves all of the new entities into
+    * the repository.
+    *
+    * @param data the data to create the new Post entities
+    * @return a sequence of the new created Post entities
+    */
   def createSeveralPosts(createUpdateData: Seq[CreateReplacePostData]): Future[Seq[Post]] = {
     def buildEntities(ids: Seq[String]): Future[Seq[Post]] = Future.successful {
       (ids zip createUpdateData) map {
@@ -27,7 +48,7 @@ class PostService(repository: PostRepository) extends Service {
     }
 
     // Save
-    val result: Future[Seq[Post]] =
+    val result =
       for {
         ids <- repository.nextIds(createUpdateData.size)
         entities <- buildEntities(ids)
@@ -37,22 +58,52 @@ class PostService(repository: PostRepository) extends Service {
     result
   }
 
+  /**
+    * It retrieves a [[model.Post Post]] by its Id from the repository.
+    *
+    * @param id the Id of the [[model.Post Post]] to retrieve
+    * @return an [[scala.Option Option]] result with the requested [[model.Post Post]] if any
+    */
   def retrievePost(id: String): Future[Option[Post]] =
     repository.find(id)
 
+  /**
+    * It retrieves a [[model.Page Page]] of [[model.Post Post]] entities from
+    * the repository for the given [[model.PaginationOptions PaginationOptions]].
+    *
+    * @param po the [[model.PaginationOptions PaginationOptions]] to determine which [[model.Page Page]] of results to return
+    * @return a [[model.Page Page]] of [[model.Post Post]] entities
+    */
   def retrievePosts()(implicit po: PaginationOptions): Future[Page[Post]] =
     repository.findAll()
 
+
+  /**
+    * It retrieves a [[model.Page Page]] of [[model.Post Post]]
+    * entities from the repository matching the given title.
+    *
+    * @param title title to find Posts by
+    * @param po the [[model.PaginationOptions PaginationOptions]] to determine which [[model.Page Page]] of results to return
+    * @return a [[model.Page Page]] of [[model.Post Post]] entities
+    */
   def retrievePostsByTitle(title: String)(implicit po: PaginationOptions): Future[Page[Post]] =
     repository.findByTitle(title)
 
+  /**
+    * It looks up a [[model.Post Post]] for the given Id and replaces it
+    * with the given [[model.CreateReplacePostData CreateReplacePostData]] if any.
+    *
+    * @param id the Id of the Post to replace
+    * @param data the data to replace the Post with
+    * @return an [[scala.Option Option]] result with the replaced [[model.Post Post]] if any
+    */
   def replacePost(id: String, data: CreateReplacePostData): Future[Option[Post]] = {
-    def replace(): Future[Post] = {
+    def replace() = {
       val postEntity = Post(id, data.title, data.tags)
       repository.save(postEntity)
     }
 
-    val result: Future[Option[Post]] =
+    val result =
       retrievePost(id) flatMap {
         case Some(_) => replace().map(Some(_))
         case None    => Future.successful(None)
@@ -61,6 +112,12 @@ class PostService(repository: PostRepository) extends Service {
     result
   }
 
+  /**
+    * It deletes a [[model.Post Post]] from the repository for the given Id.
+    *
+    * @param id the Id of the [[model.Post Post]] to delete
+    * @return an [[scala.Option Option]] result with the deleted [[model.Post Post]] if any
+    */
   def deletePost(id: String): Future[Option[Post]] =
     repository.remove(id)
 

--- a/scala/faunadb-crud-example-app/src/main/scala/services/common.scala
+++ b/scala/faunadb-crud-example-app/src/main/scala/services/common.scala
@@ -3,11 +3,14 @@ package services
 import scala.concurrent.ExecutionContext
 
 /**
-  * Base trait for implementing Domain Services
+  * Base trait for implementing Domain Services.
   */
 trait Service {
-  // Note: using Scala's global ExecutionContext for now.
-  // Evaluate the use of a dedicated ExecutionContext for
-  // the services layer (bulkheading) in a prod environment.
+  /*
+   * Note: using Scala's global ExecutionContext for keeping
+   * the example with a simple design. Evaluate the use of a
+   * dedicated ExecutionContext for the service layer
+   * (bulkheading) in a prod environment.
+   */
   implicit protected val ec: ExecutionContext = ExecutionContext.global
 }


### PR DESCRIPTION
Adding missing ScalaDocs to Scala CRUD example in order to provide further explanations on Fauna features and their usages as well as some of the design decisions that have been made when putting the code together.